### PR TITLE
move device ids for in-a-box

### DIFF
--- a/workbench/compose.yaml
+++ b/workbench/compose.yaml
@@ -51,7 +51,7 @@ services:
           devices:
             - driver: nvidia
               # count: ${INFERENCE_GPU_COUNT:-all}
-              device_ids: ['${EMBEDDING_MS_GPU_ID:-1}']
+              device_ids: ['${EMBEDDING_MS_GPU_ID:-5}']
               capabilities: [gpu]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health/ready"]
@@ -86,7 +86,7 @@ services:
           devices:
             - driver: nvidia
               # count: ${INFERENCE_GPU_COUNT:-all}
-              device_ids: ['${RANKING_MS_GPU_ID:-1}']
+              device_ids: ['${RANKING_MS_GPU_ID:-5}']
               capabilities: [gpu]
     profiles: ["local"]
 
@@ -118,7 +118,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              device_ids: ['${YOLOX_MS_GPU_ID:-0}']
+              device_ids: ['${YOLOX_MS_GPU_ID:-4}']
               capabilities: [gpu]
     runtime: nvidia
     profiles: ["local"]
@@ -142,7 +142,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              device_ids: ['${YOLOX_GRAPHICS_MS_GPU_ID:-0}']
+              device_ids: ['${YOLOX_GRAPHICS_MS_GPU_ID:-4}']
               capabilities: [gpu]
     runtime: nvidia
     profiles: ["local"]
@@ -165,7 +165,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              device_ids:  ['${YOLOX_TABLE_MS_GPU_ID:-0}']
+              device_ids:  ['${YOLOX_TABLE_MS_GPU_ID:-4}']
               capabilities: [gpu]
     runtime: nvidia
     profiles: ["local"]
@@ -189,7 +189,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              device_ids:  ['${PADDLE_MS_GPU_ID:-0}']
+              device_ids:  ['${PADDLE_MS_GPU_ID:-4}']
               capabilities: [gpu]
     runtime: nvidia
     profiles: ["local"]
@@ -534,7 +534,7 @@ services:
             - driver: nvidia
               capabilities: ["gpu"]
               # count: ${INFERENCE_GPU_COUNT:-all}
-              device_ids: ['${VECTORSTORE_GPU_DEVICE_ID:-0}']
+              device_ids: ['${VECTORSTORE_GPU_DEVICE_ID:-4}']
     profiles: ["vectordb"]
 
   etcd:


### PR DESCRIPTION
use different device ids for in a box where nemotron is on 0,1 0 becomes 4
1 becomes 5

(the 2, 3 remain the same and are used by nim_llm)